### PR TITLE
Add paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,5 +3,6 @@ version=1.0.0
 author=Michael Brunner
 maintainer=Michael Brunner <MichaelBrunn3r@gmail.com>
 sentence=A collection of Collections for Arduino
+paragraph=
 category=Display
 url=https://github.com/MichaelBrunn3r/ArduinoCollections


### PR DESCRIPTION
When the paragraph field is missing from library.properties, the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format